### PR TITLE
Moved to src, add instrumentation to import reflect-metadata

### DIFF
--- a/src/app/api/v1/checkly/alertreceiver/route.ts
+++ b/src/app/api/v1/checkly/alertreceiver/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, NextRequest } from "next/server";
 import { plainToInstance } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
-import { WebhookAlertDto } from '../../../../../src/checkly/alertDTO';
-import 'reflect-metadata';
+import { WebhookAlertDto } from '../../../../../checkly/alertDTO';
+
 export async function GET() {
 	return NextResponse.json({ message: "Hello from Next.js!" });
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,4 @@
+import 'reflect-metadata';
+export function register() {
+    console.log('Registering instrumentation');
+  }


### PR DESCRIPTION
This pull request includes changes to the `src/app/api/v1/checkly/alertreceiver/route.ts` and `src/instrumentation.ts` files. The most important changes involve the renaming of a file and the addition of a new function for registering instrumentation.

File renaming and import adjustments:

* [`src/app/api/v1/checkly/alertreceiver/route.ts`](diffhunk://#diff-1874d584786774086eff29fb4250b16fbd4ce889822c454ade159120755052ecL4-R5): The file was renamed from `app/api/v1/checkly/alertreceiver/route.ts` and the import path for `WebhookAlertDto` was updated accordingly.

New functionality:

* [`src/instrumentation.ts`](diffhunk://#diff-1d5bbd60ea57ea5431ebe7f03e6a47d12e205b27e1b04d9e2a046fafde4bbb2cR1-R4): Added a new function `register` that logs a message "Registering instrumentation" and included the `reflect-metadata` import.