### PR TITLE
disable vercel deploy, add render deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,8 @@ jobs:
           unzip render.zip
           sudo mv cli_v0.8.5 /usr/local/bin/render
       - name: Authenticate with Render
-        run: render login
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+        run: render login
       - name: Trigger Render Deployment
         run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - name: Install Render CLI
         run: |
-          brew tap render-oss/homebrew-render
-          brew update
-          brew install render
+          curl -L https://github.com/render-oss/cli/releases/download/v0.8.5/cli_0.8.5_linux_amd64.zip -o render.zip
+          unzip render.zip
+          sudo mv render /usr/local/bin/
       - name: Authenticate with Render
         run: render login --api-key ${{ secrets.RENDER_API_KEY }}
       - name: Trigger Render Deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           curl -L https://github.com/render-oss/cli/releases/download/v0.8.5/cli_0.8.5_linux_amd64.zip -o render.zip
           unzip render.zip
-          sudo mv cli_v0.8.5 /usr/local/bin/render
+          sudo mv cli_v0.8.6 /usr/local/bin/render
       - name: Authenticate with Render
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,5 +33,7 @@ jobs:
           sudo mv cli_v0.8.5 /usr/local/bin/render
       - name: Authenticate with Render
         run: render login
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
       - name: Trigger Render Deployment
         run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,16 @@
-name: Vercel Production Deployment
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+name: Deployment
+
 on:
   push:
     branches:
       - main
+  pull_request:
+    branches: [main]
 
 jobs:
-  Deploy-Production:
+  Deploy-Vercel:
+    if: false
+    #Temporarily disabled
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,3 +22,14 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+  Deploy-Render:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Render CLI
+        run: npm install -g @render/cli
+      - name: Authenticate with Render
+        run: render login --api-key ${{ secrets.RENDER_API_KEY }}
+      - name: Trigger Render Deployment
+        run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,6 @@ jobs:
           CI: true
         run: render login --output json
       - name: Trigger Render Deployment
-        run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}
+        run: render deploys create ${{ secrets.RENDER_SERVICE_ID }} --output json
         env:
           CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           curl -L https://github.com/render-oss/cli/releases/download/v0.8.5/cli_0.8.5_linux_amd64.zip -o render.zip
           unzip render.zip
-          sudo mv render /usr/local/bin/
+          sudo mv cli_v0.8.5 /usr/local/bin/render
       - name: Authenticate with Render
         run: render login --api-key ${{ secrets.RENDER_API_KEY }}
       - name: Trigger Render Deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,6 @@ jobs:
           unzip render.zip
           sudo mv cli_v0.8.5 /usr/local/bin/render
       - name: Authenticate with Render
-        run: render login --api-key ${{ secrets.RENDER_API_KEY }}
+        run: render login
       - name: Trigger Render Deployment
         run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Authenticate with Render
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          CI: true
         run: render login
       - name: Trigger Render Deployment
         run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}
+        env:
+          CI: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [main]
 
 jobs:
   Deploy-Vercel:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,10 @@ jobs:
           curl -L https://github.com/render-oss/cli/releases/download/v0.8.6/cli_0.8.6_linux_amd64.zip -o render.zip
           unzip render.zip
           sudo mv cli_v0.8.6 /usr/local/bin/render
-      - name: Authenticate with Render
+      - name: Authenticate with Render& Deploy
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           CI: true
-        run: render login --output json
-      - name: Trigger Render Deployment
-        run: render deploys create ${{ secrets.RENDER_SERVICE_ID }} --output json
-        env:
-          CI: true
+        run: |
+          render login --output json
+          render deploys create ${{ secrets.RENDER_SERVICE_ID }} --output json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,9 @@ jobs:
     steps:
       - name: Install Render CLI
         run: |
-          curl -L https://github.com/renderinc/render-cli/releases/download/v0.1.0/render-cli-v0.1.0-linux-amd64.tar.gz -o render-cli.tar.gz
-          tar -xzf render-cli.tar.gz
-          sudo mv render /usr/local/bin/
+          brew tap render-oss/homebrew-render
+          brew update
+          brew install render
       - name: Authenticate with Render
         run: render login --api-key ${{ secrets.RENDER_API_KEY }}
       - name: Trigger Render Deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     #Temporarily disabled
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information
@@ -26,9 +26,11 @@ jobs:
   Deploy-Render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Install Render CLI
-        run: npm install -g @render/cli
+        run: |
+          curl -L https://github.com/renderinc/render-cli/releases/download/v0.1.0/render-cli-v0.1.0-linux-amd64.tar.gz -o render-cli.tar.gz
+          tar -xzf render-cli.tar.gz
+          sudo mv render /usr/local/bin/
       - name: Authenticate with Render
         run: render login --api-key ${{ secrets.RENDER_API_KEY }}
       - name: Trigger Render Deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install Render CLI
         run: |
-          curl -L https://github.com/render-oss/cli/releases/download/v0.8.5/cli_0.8.5_linux_amd64.zip -o render.zip
+          curl -L https://github.com/render-oss/cli/releases/download/v0.8.6/cli_0.8.6_linux_amd64.zip -o render.zip
           unzip render.zip
           sudo mv cli_v0.8.6 /usr/local/bin/render
       - name: Authenticate with Render

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           CI: true
-        run: render login
+        run: render login --output json
       - name: Trigger Render Deployment
         run: render deploy --service-id ${{ secrets.RENDER_SERVICE_ID }}
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,4 +37,4 @@ jobs:
           CI: true
         run: |
           render login --output json
-          render deploys create ${{ secrets.RENDER_SERVICE_ID }} --output json
+          render deploys create ${{ secrets.RENDER_SERVICE_ID }} --output json --confirm


### PR DESCRIPTION
This pull request includes significant changes to the deployment workflow configuration in the `.github/workflows/deploy.yml` file. The most important changes involve renaming and temporarily disabling the Vercel deployment job, updating the Vercel CLI version, and adding a new deployment job for Render.

Deployment workflow updates:

* Renamed the Vercel deployment job from `Deploy-Production` to `Deploy-Vercel` and temporarily disabled it using the `if: false` condition.
* Updated the `actions/checkout` version from `v2` to `v4` in the Vercel deployment job.
* Added a new deployment job for Render, which includes steps to install the Render CLI, authenticate with Render, and deploy the project using the Render API key.