### PR TITLE
leverage generators, add rate-limit retries

### DIFF
--- a/src/checkly/checklyclient.ts
+++ b/src/checkly/checklyclient.ts
@@ -351,7 +351,6 @@ export class ChecklyClient {
         retryOptions,
       });
       results.push(...entries);
-      console.log("entries", results.length);
       cursor = nextId;
     }
 

--- a/src/data-sync/ChecklyDataSyncer.ts
+++ b/src/data-sync/ChecklyDataSyncer.ts
@@ -18,7 +18,7 @@ export class ChecklyDataSyncer {
     const allChecks = await checkly.getChecks();
     const checkIds = allChecks.map((c) => c.id);
 
-    let totalSynchronised = 0;
+    let totalSynchronized = 0;
     for (const checkId of checkIds) {
       for await (const checkResults of checkly.getCheckResultsByCheckIdGenerator(
         checkId,
@@ -46,12 +46,12 @@ export class ChecklyDataSyncer {
           .insert(enrichedResults.map(serializeCheckResult))
           .onConflict("id")
           .merge();
-        totalSynchronised += enrichedResults.length;
+        totalSynchronized += enrichedResults.length;
       }
 
       log.info(
         {
-          count: totalSynchronised,
+          count: totalSynchronized,
           duration_ms: Date.now() - startedAt,
           checkId,
         },

--- a/src/data-sync/ChecklyDataSyncer.ts
+++ b/src/data-sync/ChecklyDataSyncer.ts
@@ -1,7 +1,8 @@
 import postgres from "../db/postgres";
 import { checkly } from "../checkly/client";
-import { Check, CheckGroup } from "../checkly/models";
+import { Check, CheckGroup, CheckResult } from "../checkly/models";
 import { log } from "../slackbot/log";
+import { promiseAllWithConcurrency } from "../lib/async-utils";
 
 export class ChecklyDataSyncer {
   constructor() {}
@@ -17,46 +18,54 @@ export class ChecklyDataSyncer {
     const allChecks = await checkly.getChecks();
     const checkIds = allChecks.map((c) => c.id);
 
-    let synchronizedResults = 0;
+    let totalSynchronised = 0;
     for (const checkId of checkIds) {
-      const checkResults = await checkly.getCheckResultsByCheckId(checkId, {
-        resultType: "ALL",
-        from,
-        to,
-        limit: 100,
-      });
-
-      for (let checkResult of checkResults) {
-        const isFailing = checkResult.hasErrors || checkResult.hasFailures;
-        if (isFailing) {
-          checkResult = await checkly.getCheckResult(checkId, checkResult.id);
-        }
+      for await (const checkResults of checkly.getCheckResultsByCheckIdGenerator(
+        checkId,
+        {
+          resultType: "ALL",
+          from,
+          to,
+          limit: 100,
+        },
+      )) {
+        const enrichStartedAt = Date.now();
+        const enrichedResults = await promiseAllWithConcurrency(
+          checkResults.map((result) => () => this.enrichResult(result)),
+          30,
+        );
+        log.debug(
+          {
+            duration_ms: Date.now() - enrichStartedAt,
+            enriched_count: enrichedResults.length,
+          },
+          "Results batch enriched",
+        );
 
         await postgres("check_results")
-          .insert(serializeCheckResult(checkResult))
+          .insert(enrichedResults.map(serializeCheckResult))
           .onConflict("id")
           .merge();
-        synchronizedResults++;
-
-        if (synchronizedResults % 100 === 0) {
-          log.info(
-            {
-              count: synchronizedResults,
-              duration_ms: Date.now() - startedAt,
-            },
-            "Check result batch synced",
-          );
-        }
+        totalSynchronised += enrichedResults.length;
       }
-    }
 
-    log.info(
-      {
-        count: synchronizedResults,
-        duration_ms: Date.now() - startedAt,
-      },
-      "Check Results synced",
-    );
+      log.info(
+        {
+          count: totalSynchronised,
+          duration_ms: Date.now() - startedAt,
+          checkId,
+        },
+        "Check Results synced",
+      );
+    }
+  }
+
+  private async enrichResult(checkResult: CheckResult): Promise<CheckResult> {
+    const isFailing = checkResult.hasErrors || checkResult.hasFailures;
+    if (!isFailing) {
+      return checkResult;
+    }
+    return checkly.getCheckResult(checkResult.checkId, checkResult.id);
   }
 
   async syncChecks() {

--- a/src/lib/async-utils.spec.ts
+++ b/src/lib/async-utils.spec.ts
@@ -1,0 +1,51 @@
+import { promiseAllWithConcurrency } from "./async-utils";
+
+describe("promiseAllWithConcurrency", () => {
+  it("should resolve all tasks with the specified concurrency", async () => {
+    const tasks = [
+      () => Promise.resolve(1),
+      () => Promise.resolve(2),
+      () => Promise.resolve(3),
+    ];
+    const concurrency = 2;
+    const results = await promiseAllWithConcurrency(tasks, concurrency);
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  it("should handle tasks that resolve at different times", async () => {
+    const tasks = [
+      () => new Promise((resolve) => setTimeout(() => resolve(1), 100)),
+      () => new Promise((resolve) => setTimeout(() => resolve(2), 50)),
+      () => new Promise((resolve) => setTimeout(() => resolve(3), 150)),
+    ];
+    const concurrency = 2;
+    const results = await promiseAllWithConcurrency(tasks, concurrency);
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  it("should handle tasks that reject", async () => {
+    const tasks = [
+      () => Promise.resolve(1),
+      () => Promise.reject(new Error("Task failed")),
+      () => Promise.resolve(3),
+    ];
+    const concurrency = 2;
+    await expect(promiseAllWithConcurrency(tasks, concurrency)).rejects.toThrow(
+      "Task failed",
+    );
+  });
+
+  it("should respect the concurrency limit", async () => {
+    const tasks = [
+      () => new Promise((resolve) => setTimeout(() => resolve(1), 100)),
+      () => new Promise((resolve) => setTimeout(() => resolve(2), 100)),
+      () => new Promise((resolve) => setTimeout(() => resolve(3), 100)),
+      () => new Promise((resolve) => setTimeout(() => resolve(4), 100)),
+    ];
+    const concurrency = 2;
+    const start = Date.now();
+    await promiseAllWithConcurrency(tasks, concurrency);
+    const duration = Date.now() - start;
+    expect(duration).toBeGreaterThanOrEqual(200);
+  });
+});

--- a/src/lib/async-utils.ts
+++ b/src/lib/async-utils.ts
@@ -11,6 +11,7 @@ export const promiseAllWithConcurrency = async <T>(
       return result;
     });
 
+    // Limit the number of concurrent promises
     results.push(await promise);
     executing.push(promise);
 

--- a/src/lib/async-utils.ts
+++ b/src/lib/async-utils.ts
@@ -1,0 +1,23 @@
+export const promiseAllWithConcurrency = async <T>(
+  tasks: (() => Promise<T>)[],
+  concurrency: number,
+): Promise<T[]> => {
+  const results: T[] = [];
+  const executing: Promise<T>[] = [];
+
+  for (const task of tasks) {
+    const promise = task().then((result) => {
+      executing.splice(executing.indexOf(promise), 1); // Remove from queue
+      return result;
+    });
+
+    results.push(await promise);
+    executing.push(promise);
+
+    if (executing.length >= concurrency) {
+      await Promise.race(executing); // Wait for one to finish
+    }
+  }
+
+  return results;
+};

--- a/src/slackbot/log.ts
+++ b/src/slackbot/log.ts
@@ -4,6 +4,7 @@ import { LogLevel } from "@slack/bolt";
 
 export const log = pino({
   level: process.env.NODE_ENV === "production" ? "info" : "debug",
+  base: null,
   transport: {
     target: "pino-logfmt",
     options: {


### PR DESCRIPTION
* Leverage generators to enable enriching individual check results between the rate-limited `GET /v2/check-results/:checkId` requests
* Add retries for rate-limited responses, use retry delay provided in response, fallback to exponential delay