### PR TITLE
Add test to extract error message from browserCheckResult after empty string

### DIFF
--- a/src/prompts/checkly-data.spec.ts
+++ b/src/prompts/checkly-data.spec.ts
@@ -103,6 +103,19 @@ describe("checkly error messages", () => {
     expect(error).toEqual("error in browser script");
   });
 
+  test("should extract error after empty string", () => {
+    const result = {
+      id: "a2283ec0-b938-4cc2-b91c-3e731fd64421",
+      browserCheckResult: {
+        errors: ["", "error in browser script"] as ErrorMessage[],
+      },
+    };
+
+    const error = getErrorMessageFromResult(result.browserCheckResult);
+
+    expect(error).toEqual("error in browser script");
+  });
+
   test("should extract browser error message", () => {
     const result = {
       id: "a2283ec0-b938-4cc2-b91c-3e731fd64421",


### PR DESCRIPTION
- Introduced a new test case to validate the extraction of error messages from the browserCheckResult when the first error is an empty string.
- Ensures that the function correctly identifies and returns the subsequent error message, enhancing test coverage for error handling.