### PR TITLE
Fix numerous bugs in the check-summary

### DIFF
--- a/src/slackbot/blocks/newCheckSummaryBlock.script.ts
+++ b/src/slackbot/blocks/newCheckSummaryBlock.script.ts
@@ -5,6 +5,7 @@ import generateCheckSummaryBlock from "./newCheckSummaryBlock";
 async function main() {
   [
     generateCheckSummaryBlock({
+      errorPatterns: [],
       checkId: "123",
       timeLocationSummary: "",
       checkName: "My Passing Check",
@@ -23,9 +24,13 @@ async function main() {
       lastFailure: new Date(),
       successRate: 0,
       failureCount: 10,
-      failurePatterns: [
-        "This is a failure pattern",
-        "This is another failure pattern",
+      errorPatterns: [
+        { description: "This is a failure pattern", count: 5553, id: "123" },
+        {
+          description: "This is another failure pattern",
+          count: 123,
+          id: "511",
+        },
       ],
     }),
     generateCheckSummaryBlock({
@@ -37,9 +42,13 @@ async function main() {
       lastFailure: new Date(),
       successRate: 0,
       failureCount: 10,
-      failurePatterns: [
-        "This is a failure pattern",
-        "This is another failure pattern",
+      errorPatterns: [
+        { description: "This is a failure pattern", count: 11, id: "123" },
+        {
+          description: "This is another failure pattern",
+          count: 12,
+          id: "511",
+        },
       ],
     }),
   ].forEach(async (block) => {

--- a/src/slackbot/commands/check-summary.script.ts
+++ b/src/slackbot/commands/check-summary.script.ts
@@ -1,16 +1,18 @@
 import * as fs from "node:fs";
 
 import { initConfig } from "../../lib/init-config";
+import { checkSummary } from "./check-summary";
 
 initConfig();
 
-import { checkSummary } from "./check-summary";
-
 const main = async () => {
-  const checkId = "7017a27e-df7b-4501-a738-fa616782bc4e";
+  const checkId = "13a60bda-0edc-470d-855e-7d092a1cca1c";
   const result = await checkSummary(checkId);
-  fs.writeFileSync(`heatmap-${checkId}.png`, result.image);
   console.log(JSON.stringify(result.message, null, 2));
+
+  if (result.image) {
+    fs.writeFileSync(`heatmap-${checkId}.png`, result.image);
+  }
 };
 
 main();

--- a/src/slackbot/commands/check-summary.ts
+++ b/src/slackbot/commands/check-summary.ts
@@ -153,7 +153,7 @@ export async function checkSummary(checkId: string) {
   const lastFailure =
     failingCheckResults.length > 0
       ? mostRecentFailureCheckResult.startedAt
-      : checkResults[0]?.startedAt;
+      : undefined;
 
   const successRate =
     checkResults.length > 0


### PR DESCRIPTION
* Fix how error patterns are presented
* Show only error patterns for last 24h
* Remove duplicate heatmap analysis
* Parallelize analysis operations
* Add fallbacks for empty state

* Caveta: Notion access is slow - It turns out that currently fetching data from Notion is taking 6s and slowing down most of our commands. Handeled in #84       