### PR TITLE
Add better error handling. Fallback to scheduling issues

### DIFF
--- a/src/data-import/DataInserter.ts
+++ b/src/data-import/DataInserter.ts
@@ -56,12 +56,15 @@ export class CheckResultsInserter {
   }
 
   private async generateClustering(checkResults: CheckResult[]) {
-    let errorMessages: string[] = [];
-    try {
-      errorMessages = checkResults.map(getErrorMessageFromCheckResult);
-    } catch (err) {
-      console.log(err);
-    }
+    const errorMessages: string[] = checkResults.map((result) => {
+      try {
+        return getErrorMessageFromCheckResult(result);
+      } catch (err) {
+        throw new Error(
+          `Failed to get error message from check result: ${result.id} Message: ${err.message}`,
+        );
+      }
+    });
     await this.generateMissingEmbeddings(errorMessages);
 
     for (let i = 0; i < checkResults.length; i++) {

--- a/src/data-import/PublicApiImporter.ts
+++ b/src/data-import/PublicApiImporter.ts
@@ -63,7 +63,7 @@ export class PublicApiImporter {
     );
   }
 
-  private getCheckIdsToSync = async () => {
+  private async getCheckIdsToSync(): Promise<string[]> {
     const allChecks = await checkly.getChecks();
     const groups = await checkly.getCheckGroups();
     const groupsById = keyBy(groups, "id");
@@ -83,7 +83,7 @@ export class PublicApiImporter {
         return c.activated;
       })
       .map((c) => c.id);
-  };
+  }
 
   private async syncResultsForCheck(
     checkId: string,

--- a/src/prompts/checkly-data.spec.ts
+++ b/src/prompts/checkly-data.spec.ts
@@ -158,6 +158,6 @@ describe("checkly error messages", () => {
   test("should safely fallback when errors are missing", () => {
     const error = getErrorMessageFromResult({});
 
-    expect(error).toEqual("No Error provided");
+    expect(error).toEqual("Scheduling error");
   });
 });

--- a/src/prompts/checkly-data.spec.ts
+++ b/src/prompts/checkly-data.spec.ts
@@ -154,4 +154,10 @@ describe("checkly error messages", () => {
 
     expect(error).toEqual("error in multi-step script");
   });
+
+  test("should safely fallback when errors are missing", () => {
+    const error = getErrorMessageFromResult({});
+
+    expect(error).toEqual("No Error provided");
+  });
 });

--- a/src/prompts/checkly-data.ts
+++ b/src/prompts/checkly-data.ts
@@ -72,19 +72,21 @@ export function getErrorMessageFromCheckResult(
 }
 
 export function getErrorMessageFromResult(result: {
-  errors: ErrorMessage[];
+  errors?: ErrorMessage[];
 }): string {
-  return (
-    result.errors
-      .map((e) => {
-        if (typeof e === "string") {
-          return e;
-        }
-        return e.message;
-      })
-      .find((e) => !!e) || "No Error provided"
-  );
+  const errorFromMessages = result.errors
+    ?.map((e) => {
+      if (typeof e === "string") {
+        return e;
+      }
+      return e.message;
+    })
+    .find((e) => !!e);
+
+  // TODO public API is not yet returning scheduling errors. We can deal with this later
+  return errorFromMessages || "Scheduling error"; // Fallback to scheduling issues
 }
+
 export function getErrorMessageFromApiError(checkResult: CheckResult): string {
   const assertionErrors =
     checkResult.apiCheckResult?.assertions


### PR DESCRIPTION
* Add better error message (to give us result id when finding error message fails)
* Fallback to scheduling issues when no error is found